### PR TITLE
Jenny/gp 46/auto decided whether the env os is window or macos 2

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ pre-commit install --install-hooks
 cd .\src\chatbot
 ```
 Copy the `example.env` in the root, rename the copied one to `.env`, and add the settings below. You can get these variables in LINE Developers Account's Settings.
-```env
+According to the operation you use, you need to choose the architecture(amd/arm) for the project.```env
 CHANNEL_SECRET=[YOUR_CHANNEL_SECRET]
 CHANNEL_ACCESS_TOKEN=[YOUR_CHANNEL_ACCESS_TOKEN]
 ```

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '3.8'
 services:
   app:
-    platform: linux/amd64
+    platform: ${DOCKER_PLATFORM}
     build: .
     image: my-python-dev-env
     volumes:
@@ -12,7 +12,6 @@ services:
     command: uvicorn src.main:app --host 0.0.0.0 --port 8777 --reload
     container_name: graduation-project
     environment:
-      PYTHONPATH: "/path/to/your/project_root/src:${PYTHONPATH}"
       POSTGRES_USER: ${POSTGRES_USER}
       POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
       POSTGRES_DB: ${POSTGRES_DB}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,6 +12,7 @@ services:
     command: uvicorn src.main:app --host 0.0.0.0 --port 8777 --reload
     container_name: graduation-project
     environment:
+      PYTHONPATH: "/path/to/your/project_root/src:${PYTHONPATH}"
       POSTGRES_USER: ${POSTGRES_USER}
       POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
       POSTGRES_DB: ${POSTGRES_DB}

--- a/example.env
+++ b/example.env
@@ -11,3 +11,9 @@ MONGO_HOST="mongodb"
 MONGO_PORT="27017"
 MONGO_DB="test_db"
 MONGO_COLLECTION="test_collection"
+
+# Use this on macOS or if running on AMD64 architecture
+DOCKER_PLATFORM="linux/arm64"
+
+# platform: # Use this on Windows OS if running on ARM64 architecture
+DOCKER_PLATFORM="linux/amd64"


### PR DESCRIPTION
-  choose the  architecture(amd/arm) from the `.env` file
- key your platform to run the docker in your own `.env` file.
- you can reference the `example.env`

## Test
Rebuild and recompose up the image, and see whether there's a warning sign for the image.