### PR TITLE
Jenny/gp 83/create hot reload for frontend

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,28 @@ Before setting up your development environment, it's essential to have Docker in
 
 Refer to the official Docker documentation for installation instructions tailored to your OS: [Docker Installation](https://www.docker.com/products/docker-desktop/).
 
+
+### For Windows Developers
+If you are using Windows, you will need to enable the Windows Subsystem for Linux (WSL) feature. Here’s a step-by-step guide:
+
+**1. Install WSL**
+```bash
+# Follow the instructions here: https://learn.microsoft.com/zh-tw/windows/wsl/install
+wsl --install
+```
+**2. Set up Docker Desktop**: [official guide](https://learn.microsoft.com/zh-tw/windows/wsl/tutorials/wsl-containers) to configure Docker Desktop.
+
+**3. Clone the Project**:  Clone this project into the path `\\wsl.localhost\Ubuntu\home\${username}`, as shown below:
+![image](https://github.com/Fang-4-Group/Graduation-Project/assets/104518723/5a5d7e10-d845-4882-b568-522d0c36502d)
+
+**4. Open the Project**: Open the project from the WSL file system, preferably using Visual Studio Code:
+![image](https://github.com/Fang-4-Group/Graduation-Project/assets/104518723/127b6a3f-5bc0-47d5-9ca8-6ec60f0e1ac2)
+
+**5. Settings in the vscode**: 
+- open setting of vscode
+- search `security.allowedUNCHosts`
+- click Add item, and fill in `wsl.localhost`
+
 ### Launching the API Service Locally
 Ensure Docker is installed on your machine before proceeding. Here are the commands to build the Docker image, deploy containers, and initiate the API service in your local environment:
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -58,7 +58,7 @@ services:
       context: ./frontend
       dockerfile: Dockerfile
     volumes:
-      - ./frontend:/app
+      - ./frontend:/app:cached
       - /app/node_modules
     ports:
       - "8081:8081"

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -8,7 +8,7 @@
       "name": "frontend",
       "version": "0.1.0",
       "dependencies": {
-        "@line/liff": "^2.3.0",
+        "@line/liff": "^2.23.2",
         "core-js": "^3.8.3",
         "vue": "^3.2.13"
       },

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -8,9 +8,9 @@
     "lint": "vue-cli-service lint"
   },
   "dependencies": {
+    "@line/liff": "^2.23.2",
     "core-js": "^3.8.3",
-    "vue": "^3.2.13",
-    "@line/liff": "^2.3.0"
+    "vue": "^3.2.13"
   },
   "devDependencies": {
     "@babel/core": "^7.12.16",

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,7 +13,6 @@ pytest
 python-dotenv
 PyYAML==6.0.1
 requests
-requests
 services
 uvicorn
 uvicorn[standard]

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,5 +14,6 @@ python-dotenv
 PyYAML==6.0.1
 requests
 requests
+services
 uvicorn
 uvicorn[standard]


### PR DESCRIPTION
- fix the error that the chatbot cannot be built by uvicorn by adding the `services` package in the `requirements.txt`
- fix the error that the `"@line/liff"` would cause the error when `npm run serve` during the frontend building

reference: https://github.com/vuejs/vue-cli/issues/4421

## For Windows Developers
If you are using Windows, you will need to enable the Windows Subsystem for Linux (WSL) feature. Here’s a step-by-step guide:

**1. Install WSL**
```bash
# Follow the instructions here: https://learn.microsoft.com/zh-tw/windows/wsl/install
wsl --install
```
**2. Set up Docker Desktop**: [official guide](https://learn.microsoft.com/zh-tw/windows/wsl/tutorials/wsl-containers) to configure Docker Desktop.

**3. Clone the Project**:  Clone this project into the path `\\wsl.localhost\Ubuntu\home\${username}`, as shown below:
![image](https://github.com/Fang-4-Group/Graduation-Project/assets/104518723/5a5d7e10-d845-4882-b568-522d0c36502d)

**4. Open the Project**: Open the project from the WSL file system, preferably using Visual Studio Code:
![image](https://github.com/Fang-4-Group/Graduation-Project/assets/104518723/127b6a3f-5bc0-47d5-9ca8-6ec60f0e1ac2)
