### PR TITLE
[GP-49] add get house info and house embedding api

### DIFF
--- a/database/migrations/pg_CRUD.py
+++ b/database/migrations/pg_CRUD.py
@@ -115,3 +115,20 @@ class PosgresqClient:
                 return {
                     "message": f"Error when selecting data: {str(e)}",
                 }
+
+    async def get_house_info(self) -> dict:
+        async with self.access_db() as conn:
+            try:
+                data = await conn.fetch(
+                    """
+                    SELECT
+                        *
+                    FROM
+                        "HOUSE"
+                    """
+                )
+                return {"message": data}
+            except Exception as e:
+                return {
+                    "message": f"Error when selecting data: {str(e)}",
+                }

--- a/src/app/route.py
+++ b/src/app/route.py
@@ -11,6 +11,7 @@ from database.seeds.pg_api_for_testing import PosgresqTestClient
 from src.data_pipeline.user_embedding import UserEmbedding
 
 from ..services.google_oidc.oidc import OIDCService
+from src.data_pipeline.item_embedding import ItemEmbedding
 
 router = APIRouter()
 oidc_service = OIDCService()
@@ -201,4 +202,18 @@ async def auth(request: Request):
 async def embedding(k_mean: bool = 0, n_clusters: int = 3):
     client = UserEmbedding()
     result = client.embedding(k_mean, n_clusters)
+    return result
+
+
+@router.get("/get_house_info/")
+async def get_house_info():
+    client = PosgresqClient()
+    result = await client.get_house_info()
+    return result
+
+
+@router.get("/item_embedding/")
+async def item_embedding():
+    client = ItemEmbedding()
+    result = await client.item_embedding()
     return result

--- a/src/data_pipeline/item_embedding.py
+++ b/src/data_pipeline/item_embedding.py
@@ -1,0 +1,45 @@
+import aiohttp
+import numpy as np
+import pandas as pd
+from fastapi.responses import JSONResponse
+
+
+class ItemEmbedding:
+    def __init__(self):
+        self.server_path = "http://localhost:7877/"
+        self.url_item = self.server_path + "get_house_info/"
+
+    async def fetch_data(self, session, url):
+        async with session.get(url) as response:
+            return await response.json()
+
+    async def item_embedding(self):
+        try:
+            async with aiohttp.ClientSession() as session:
+                response = await self.fetch_data(session, self.url_item)
+                df = pd.DataFrame(response["message"])
+
+                # one-hot encoding
+                encoded = pd.get_dummies(df[["Type"]], dtype="int")
+
+                # 合併 one-hot 編碼的列
+                df = pd.concat([df, encoded], axis=1)
+
+                # 刪除原始的 Fire, Negotiate_Price, Type 列
+                df.drop(columns=["Type"], inplace=True)
+
+                # 替换NaN和Infinity值
+                df.replace([np.inf, -np.inf], np.nan, inplace=True)
+                df.fillna(0, inplace=True)
+
+                dict_data = df.to_dict(orient="records")
+                return JSONResponse(content=dict_data)
+
+        except Exception as e:
+            import traceback
+
+            error_message = traceback.format_exc()
+            return {
+                "message": f"Error when embedding user feature: {str(e)}",
+                "details": error_message,
+            }

--- a/tests/unit/app/test_route.py
+++ b/tests/unit/app/test_route.py
@@ -98,3 +98,16 @@ def test_embedding():
     par = f"?k_mean={k_mean}&n_clusters={n_clusters}"
     response = client.get(f"user_embedding/{par}")
     assert response.status_code == 200
+    assert response.json()  # assure that there are content in response
+
+
+def test_get_house_info():
+    response = client.get("/get_house_info/")
+    assert response.status_code == 200
+    assert response.json()
+
+
+def test_item_embedding():
+    response = client.get("/item_embedding/")
+    assert response.status_code == 200
+    assert response.json()


### PR DESCRIPTION
## Changes
- pg_CRUD
  - Add get_house_info func.
- item embedding function
  - the place is for filtering, so I didn't embedding the three column.
- route.py
  - Add get_house_info, item_embedding route
 
## Test
1. pull this branch content
2. run the following command
    ```
    # Deploying the service using Docker Compose
    docker-compose up -d
    
    # Accessing the container's shell
    docker exec -it graduation-project /bin/bash
    
    # Starting the API service with Uvicorn on localhost
    uvicorn src.main:app --host localhost --port 7877 --reload
    ```
3. click http://localhost:7877/item_embedding/

Then you will see all house info with embedding column: Type